### PR TITLE
Add Firebase client management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Getting Started with Create React App
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+It provides a simple interface for testing protected APIs using Firebase
+authentication. You can log in with email/password, anonymously or with a
+custom token. Custom tokens can be saved as **clients** so they can be quickly
+used again later. Saved clients are persisted in your browser's local storage
+and can be removed from the interface.
 
 ## Available Scripts
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 It provides a simple interface for testing protected APIs using Firebase
 authentication. You can log in with email/password, anonymously or with a
-custom token. Custom tokens can be saved as **clients** so they can be quickly
-used again later. Each client stores its own Firebase configuration and token.
-Saved clients are persisted in your browser's local storage and can be removed
-from the interface.
+  custom token. Custom tokens can be saved as **clients** so they can be quickly
+  used again later. Each client stores its own Firebase configuration and token.
+  Saved clients are persisted in your browser's local storage and can be removed
+  or edited directly in the interface using the "Edit Token" button next to each
+  client.
 
 ## Available Scripts
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 It provides a simple interface for testing protected APIs using Firebase
 authentication. You can log in with email/password, anonymously or with a
 custom token. Custom tokens can be saved as **clients** so they can be quickly
-used again later. Saved clients are persisted in your browser's local storage
-and can be removed from the interface.
+used again later. Each client stores its own Firebase configuration and token.
+Saved clients are persisted in your browser's local storage and can be removed
+from the interface.
 
 ## Available Scripts
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,9 @@
 import React, { useState, useEffect } from "react";
-import {
-  createAuth,
-  defaultConfig,
-  signInWithEmailAndPassword,
-  signInAnonymously,
-  onAuthStateChanged,
-} from "./firebase";
-import { signInWithCustomToken, signOut } from "firebase/auth";
+import { createAuth, defaultConfig, onAuthStateChanged } from "./firebase";
+import { signOut } from "firebase/auth";
+import SignInForms from "./components/SignInForms";
+import SavedClients from "./components/SavedClients";
+import UserPanel from "./components/UserPanel";
 
 // Initialize default Firebase auth
 const initialAuth = createAuth(defaultConfig);
@@ -14,16 +11,9 @@ const initialAuth = createAuth(defaultConfig);
 function App() {
   const [auth, setAuth] = useState(initialAuth);
   const [user, setUser] = useState(null);
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [serverMessage, setServerMessage] = useState("");
-  const [cToken, setCToken] = useState("");
   const [fToken, setFToken] = useState(null);
   const [copied, setCopied] = useState(false);
-  const [clients, setClients] = useState([]);
-  const [newClientName, setNewClientName] = useState("");
-  const [newClientToken, setNewClientToken] = useState("");
-  const [newClientConfig, setNewClientConfig] = useState("");
 
   // Track Auth State
   useEffect(() => {
@@ -34,54 +24,7 @@ function App() {
     return () => unsubscribe();
   }, [auth]);
 
-  useEffect(() => {
-    const stored = localStorage.getItem("firebaseClients");
-    if (stored) {
-      try {
-        setClients(JSON.parse(stored));
-      } catch (_) {
-        setClients([]);
-      }
-    }
-  }, []);
 
-  const handleSignInWithCustomToken = async () => {
-    try {
-      // Example: Fetch the custom token from your backend
-      // const response = await fetch(
-      //   "http://localhost:3000/auth/get-custom-token",
-      //   {
-      //     method: "GET",
-      //     // or POST if needed
-      //   }
-      // );
-      // const data = await response.json();
-      // const { customToken } = data;
-
-      // 4. Sign in with the custom token
-      await signInWithCustomToken(auth, cToken);
-    } catch (error) {
-      console.error("SignInWithCustomToken Error:", error);
-    }
-  };
-
-  // Sign in with Email/Password
-  const handleEmailSignIn = async () => {
-    try {
-      await signInWithEmailAndPassword(auth, email, password);
-    } catch (error) {
-      console.error("Email Sign-In Error:", error);
-    }
-  };
-
-  // Sign in Anonymously
-  const handleAnonymousSignIn = async () => {
-    try {
-      await signInAnonymously(auth);
-    } catch (error) {
-      console.error("Anonymous Sign-In Error:", error);
-    }
-  };
 
   // Call the protected route
   const callProtectedEndpoint = async () => {
@@ -131,149 +74,25 @@ function App() {
     }
   };
 
-  const persistClients = (list) => {
-    setClients(list);
-    localStorage.setItem("firebaseClients", JSON.stringify(list));
-  };
-
-  const addClient = () => {
-    if (!newClientName || !newClientToken || !newClientConfig) return;
-    let configObj;
-    try {
-      configObj = JSON.parse(newClientConfig);
-    } catch (e) {
-      console.error("Invalid config JSON", e);
-      return;
-    }
-    const updated = [
-      ...clients,
-      { name: newClientName, token: newClientToken, config: configObj },
-    ];
-    persistClients(updated);
-    setNewClientName("");
-    setNewClientToken("");
-    setNewClientConfig("");
-  };
-
-  const removeClient = (index) => {
-    const updated = clients.filter((_, i) => i !== index);
-    persistClients(updated);
-  };
-
-  const signInClient = async (client) => {
-    try {
-      const newAuth = createAuth(client.config);
-      setAuth(newAuth);
-      await signInWithCustomToken(newAuth, client.token);
-    } catch (error) {
-      console.error("SignInWithCustomToken Error:", error);
-    }
-  };
 
   return (
     <div style={{ maxWidth: 600, margin: "0 auto" }}>
       <h1>Firebase Auth Demo</h1>
       {user ? (
-        <>
-          <p>Signed in as: {user.uid}</p>
-          <button onClick={callProtectedEndpoint}>
-            Call Protected Endpoint
-          </button>
-          {serverMessage && (
-            <pre style={{ background: "#f4f4f4", padding: "10px" }}>
-              {serverMessage}
-            </pre>
-          )}
-          <button onClick={handleShowFToken}>Show Token</button>
-          {fToken && (
-            <>
-              <pre style={{ background: "#f4f4f4", padding: "10px" }}>
-                {fToken}
-              </pre>
-              <button onClick={copyToClipboard}>Copy</button>
-            </>
-          )}
-          <button onClick={handleLogout} style={{ marginLeft: "1rem" }}>
-            Logout
-          </button>
-        </>
+        <UserPanel
+          user={user}
+          serverMessage={serverMessage}
+          fToken={fToken}
+          copied={copied}
+          onProtected={callProtectedEndpoint}
+          onShowToken={handleShowFToken}
+          onCopyToken={copyToClipboard}
+          onLogout={handleLogout}
+        />
       ) : (
         <>
-          <div>
-            <h2>Sign In with Email/Password</h2>
-            <input
-              placeholder="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              style={{ marginRight: 8 }}
-            />
-            <input
-              placeholder="Password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              style={{ marginRight: 8 }}
-            />
-            <button onClick={handleEmailSignIn}>Sign In</button>
-          </div>
-          <div>
-            <h2>Or Sign In Anonymously</h2>
-            <button onClick={handleAnonymousSignIn}>Go Anonymous</button>
-          </div>
-          <div>
-            <h2>Sign In Custom Token</h2>
-            <input
-              placeholder="Customer token"
-              value={cToken}
-              onChange={(e) => setCToken(e.target.value)}
-              style={{ marginRight: 8 }}
-            />
-            <button onClick={handleSignInWithCustomToken}>
-              Go Custom Token
-            </button>
-          </div>
-          <div>
-            <h2>Saved Clients</h2>
-            {clients.map((c, idx) => (
-              <div key={idx} style={{ marginBottom: 8 }}>
-                <strong>{c.name}</strong>
-                <button
-                  onClick={() => signInClient(c)}
-                  style={{ marginLeft: 8 }}
-                >
-                  Sign In
-                </button>
-                <button
-                  onClick={() => removeClient(idx)}
-                  style={{ marginLeft: 4 }}
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
-            <div>
-              <input
-                placeholder="Name"
-                value={newClientName}
-                onChange={(e) => setNewClientName(e.target.value)}
-                style={{ marginRight: 8 }}
-              />
-              <input
-                placeholder="Token"
-                value={newClientToken}
-                onChange={(e) => setNewClientToken(e.target.value)}
-                style={{ marginRight: 8 }}
-              />
-              <textarea
-                placeholder="Firebase config JSON"
-                value={newClientConfig}
-                onChange={(e) => setNewClientConfig(e.target.value)}
-                style={{ marginRight: 8, display: "block", width: "100%" }}
-                rows={3}
-              />
-              <button onClick={addClient}>Add</button>
-            </div>
-          </div>
+          <SignInForms auth={auth} />
+          <SavedClients setAuth={setAuth} />
         </>
       )}
     </div>

--- a/src/components/SavedClients.js
+++ b/src/components/SavedClients.js
@@ -1,0 +1,101 @@
+import React, { useState, useEffect } from "react";
+import { signInWithCustomToken } from "firebase/auth";
+import { createAuth } from "../firebase";
+
+function SavedClients({ setAuth }) {
+  const [clients, setClients] = useState([]);
+  const [newClientName, setNewClientName] = useState("");
+  const [newClientToken, setNewClientToken] = useState("");
+  const [newClientConfig, setNewClientConfig] = useState("");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("firebaseClients");
+    if (stored) {
+      try {
+        setClients(JSON.parse(stored));
+      } catch (_) {
+        setClients([]);
+      }
+    }
+  }, []);
+
+  const persistClients = (list) => {
+    setClients(list);
+    localStorage.setItem("firebaseClients", JSON.stringify(list));
+  };
+
+  const addClient = () => {
+    if (!newClientName || !newClientToken || !newClientConfig) return;
+    let configObj;
+    try {
+      configObj = JSON.parse(newClientConfig);
+    } catch (e) {
+      console.error("Invalid config JSON", e);
+      return;
+    }
+    const updated = [
+      ...clients,
+      { name: newClientName, token: newClientToken, config: configObj },
+    ];
+    persistClients(updated);
+    setNewClientName("");
+    setNewClientToken("");
+    setNewClientConfig("");
+  };
+
+  const removeClient = (index) => {
+    const updated = clients.filter((_, i) => i !== index);
+    persistClients(updated);
+  };
+
+  const signInClient = async (client) => {
+    try {
+      const newAuth = createAuth(client.config);
+      setAuth(newAuth);
+      await signInWithCustomToken(newAuth, client.token);
+    } catch (error) {
+      console.error("SignInWithCustomToken Error:", error);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Saved Clients</h2>
+      {clients.map((c, idx) => (
+        <div key={idx} style={{ marginBottom: 8 }}>
+          <strong>{c.name}</strong>
+          <button onClick={() => signInClient(c)} style={{ marginLeft: 8 }}>
+            Sign In
+          </button>
+          <button onClick={() => removeClient(idx)} style={{ marginLeft: 4 }}>
+            Remove
+          </button>
+        </div>
+      ))}
+      <div>
+        <input
+          placeholder="Name"
+          value={newClientName}
+          onChange={(e) => setNewClientName(e.target.value)}
+          style={{ marginRight: 8 }}
+        />
+        <input
+          placeholder="Token"
+          value={newClientToken}
+          onChange={(e) => setNewClientToken(e.target.value)}
+          style={{ marginRight: 8 }}
+        />
+        <textarea
+          placeholder="Firebase config JSON"
+          value={newClientConfig}
+          onChange={(e) => setNewClientConfig(e.target.value)}
+          style={{ marginRight: 8, display: "block", width: "100%" }}
+          rows={3}
+        />
+        <button onClick={addClient}>Add</button>
+      </div>
+    </div>
+  );
+}
+
+export default SavedClients;

--- a/src/components/SavedClients.js
+++ b/src/components/SavedClients.js
@@ -48,6 +48,17 @@ function SavedClients({ setAuth }) {
     persistClients(updated);
   };
 
+  const editClientToken = (index) => {
+    const current = clients[index];
+    const newToken = window.prompt("Enter new token", current.token);
+    if (newToken) {
+      const updated = clients.map((c, i) =>
+        i === index ? { ...c, token: newToken } : c
+      );
+      persistClients(updated);
+    }
+  };
+
   const signInClient = async (client) => {
     try {
       const newAuth = createAuth(client.config);
@@ -69,6 +80,9 @@ function SavedClients({ setAuth }) {
           </button>
           <button onClick={() => removeClient(idx)} style={{ marginLeft: 4 }}>
             Remove
+          </button>
+          <button onClick={() => editClientToken(idx)} style={{ marginLeft: 4 }}>
+            Edit Token
           </button>
         </div>
       ))}

--- a/src/components/SignInForms.js
+++ b/src/components/SignInForms.js
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import {
+  signInWithEmailAndPassword,
+  signInAnonymously,
+  signInWithCustomToken,
+} from "firebase/auth";
+
+function SignInForms({ auth }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [cToken, setCToken] = useState("");
+
+  const handleEmailSignIn = async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+    } catch (error) {
+      console.error("Email Sign-In Error:", error);
+    }
+  };
+
+  const handleAnonymousSignIn = async () => {
+    try {
+      await signInAnonymously(auth);
+    } catch (error) {
+      console.error("Anonymous Sign-In Error:", error);
+    }
+  };
+
+  const handleSignInWithCustomToken = async () => {
+    try {
+      await signInWithCustomToken(auth, cToken);
+    } catch (error) {
+      console.error("SignInWithCustomToken Error:", error);
+    }
+  };
+
+  return (
+    <>
+      <div>
+        <h2>Sign In with Email/Password</h2>
+        <input
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          style={{ marginRight: 8 }}
+        />
+        <input
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          style={{ marginRight: 8 }}
+        />
+        <button onClick={handleEmailSignIn}>Sign In</button>
+      </div>
+      <div>
+        <h2>Or Sign In Anonymously</h2>
+        <button onClick={handleAnonymousSignIn}>Go Anonymous</button>
+      </div>
+      <div>
+        <h2>Sign In Custom Token</h2>
+        <input
+          placeholder="Customer token"
+          value={cToken}
+          onChange={(e) => setCToken(e.target.value)}
+          style={{ marginRight: 8 }}
+        />
+        <button onClick={handleSignInWithCustomToken}>Go Custom Token</button>
+      </div>
+    </>
+  );
+}
+
+export default SignInForms;

--- a/src/components/UserPanel.js
+++ b/src/components/UserPanel.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+function UserPanel({
+  user,
+  serverMessage,
+  fToken,
+  copied,
+  onProtected,
+  onShowToken,
+  onCopyToken,
+  onLogout,
+}) {
+  return (
+    <>
+      <p>Signed in as: {user.uid}</p>
+      <button onClick={onProtected}>Call Protected Endpoint</button>
+      {serverMessage && (
+        <pre style={{ background: "#f4f4f4", padding: "10px" }}>{serverMessage}</pre>
+      )}
+      <button onClick={onShowToken}>Show Token</button>
+      {fToken && (
+        <>
+          <pre style={{ background: "#f4f4f4", padding: "10px" }}>{fToken}</pre>
+          <button onClick={onCopyToken}>{copied ? "Copied!" : "Copy"}</button>
+        </>
+      )}
+      <button onClick={onLogout} style={{ marginLeft: "1rem" }}>
+        Logout
+      </button>
+    </>
+  );
+}
+
+export default UserPanel;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,4 +1,4 @@
-import { initializeApp } from "firebase/app";
+import { initializeApp, getApps } from "firebase/app";
 import {
   getAuth,
   signInWithEmailAndPassword,
@@ -6,8 +6,8 @@ import {
   onAuthStateChanged,
 } from "firebase/auth";
 
-// Copy these from your Firebase project settings
-const firebaseConfig = {
+// Default Firebase config. Replace with your project's config if needed.
+export const defaultConfig = {
   apiKey: "AIzaSyB1i2thHBG7NGM4JTPlT1L9wGP27nW8f5k",
   authDomain: "bwithyouinwza.firebaseapp.com",
   projectId: "bwithyouinwza",
@@ -16,12 +16,15 @@ const firebaseConfig = {
   appId: "1:825667949714:web:c644238659f4831d6fc24b",
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
+// Create or reuse a Firebase app and return its auth instance
+export const createAuth = (config = defaultConfig) => {
+  const name = config.projectId || `app-${getApps().length}`;
+  const existing = getApps().find((a) => a.name === name);
+  const app = existing || initializeApp(config, name);
+  return getAuth(app);
+};
 
 export {
-  auth,
   signInWithEmailAndPassword,
   signInAnonymously,
   onAuthStateChanged,

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -11,7 +11,7 @@ export const defaultConfig = {
   apiKey: "AIzaSyB1i2thHBG7NGM4JTPlT1L9wGP27nW8f5k",
   authDomain: "bwithyouinwza.firebaseapp.com",
   projectId: "bwithyouinwza",
-  storageBucket: "bwithyouinwza.firebasestorage.app",
+  storageBucket: "bwithyouinwza.appspot.com",
   messagingSenderId: "825667949714",
   appId: "1:825667949714:web:c644238659f4831d6fc24b",
 };


### PR DESCRIPTION
## Summary
- expand README with info on saved clients
- save custom token clients in localStorage
- allow adding, removing and using saved clients from the UI

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fea29a9d483328797d0187720239d